### PR TITLE
Add possibility to update server.properties in docker volume

### DIFF
--- a/start
+++ b/start
@@ -11,4 +11,4 @@ cd /minecraft
 [ -n "${ONLINE_MODE:-}" ] && sed -i -e "s/^online-mode=.*/online-mode=$ONLINE_MODE/g" /minecraft/server.properties
 
 /etc/init.d/ssh start
-echo "jsp classroom on" | /usr/bin/java -Xmx8192M -jar spigot-${MINECRAFT_VERSION}.jar
+echo "jsp classroom on" | /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx8192M -jar spigot-${MINECRAFT_VERSION}.jar

--- a/start
+++ b/start
@@ -2,7 +2,7 @@
 set -x
 set -e
 
-RSYNC_OPT=""
+RSYNC_OPT=" --update "
 [ -n "${INIT_WORLD:-}" ] && RSYNC_OPT=" --delete "
 
 rsync -a $RSYNC_OPT /opt/minecraft/ /minecraft/


### PR DESCRIPTION
- Do an `--update` rsync to not override modified files (as server.properties)
- Set JVM J8 options for correct compute of head size in a Docker container
(see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits)